### PR TITLE
ci: auto-deploy claude.do to Cloudflare on push to main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,32 @@
+name: Deploy to Cloudflare
+
+# Auto-publish claude.do on every push to main: build the Astro site and
+# deploy the Cloudflare Worker (serves ./dist via env.ASSETS).
+#
+# Requires two repo secrets (Settings → Secrets and variables → Actions):
+#   CLOUDFLARE_API_TOKEN  — a token with the **Workers Scripts: Edit** +
+#                           **Account: Read** permissions on the account below.
+#                           (The do-box's existing cloudflare_access_token is
+#                           NOT scoped for Workers — a dedicated deploy token
+#                           is needed.)
+#   CLOUDFLARE_ACCOUNT_ID — the Cloudflare account id.
+on:
+  push:
+    branches: [main]
+  workflow_dispatch: {}
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - run: npm ci
+      - run: npm run build
+      - name: Deploy Worker
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
Adds a GitHub Actions workflow that builds the Astro site and `wrangler deploy`s the Cloudflare Worker on every push to `main` (plus manual dispatch) — so publishing a post = merging to main, no manual deploy step.

## Requires two repo secrets
- `CLOUDFLARE_API_TOKEN` — a token with **Workers Scripts: Edit** + **Account: Read** on the account. ⚠️ The do-box's existing `~/.secrets/cloudflare_access_token` is valid but is **not** Workers-scoped (verified: API returns auth-error for both Workers and Pages endpoints), and `cloudflare_dns_token` is DNS-only — so a **dedicated Workers deploy token** needs to be created and added here.
- `CLOUDFLARE_ACCOUNT_ID` — the account id (in `~/.secrets/cloudflare_account_id`).

## Alternative (zero repo-secret)
Enable **Cloudflare → Workers → Builds** on the dashboard and connect this repo — Cloudflare then builds + deploys on push with no GitHub secret at all. Either path gives the same 'push to publish' result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)